### PR TITLE
Image by breed

### DIFF
--- a/src/test/java/ceo/dog/ImagesByBreedTest.java
+++ b/src/test/java/ceo/dog/ImagesByBreedTest.java
@@ -1,0 +1,37 @@
+package ceo.dog;
+
+import ceo.dog.application.Endpoints;
+import ceo.dog.application.Urls;
+import ceo.dog.application.responseParsers.AllBreeds;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ImagesByBreedTest {
+
+    @Test(groups ={"smoke", "regression"})
+    public void testStatusBreedAndFileType() {
+        String breedName = AllBreeds.getRandomBreedName();
+
+        ArrayList<String> message = given()
+                .when()
+                .get(Urls.DOG_API + Endpoints.allImagesByBreed(breedName))
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("message");
+
+        if (message.isEmpty()) {
+            throw new IllegalArgumentException("The response body message is empty.");
+        }
+
+        /* Get the first item from the list and assert it is a jpg file.
+        (the Dog API project only accepts jpg files). */
+        assertThat(message.get(0), endsWith(".jpg"));
+        assertThat(message.get(0), containsString(breedName));
+    }
+}

--- a/src/test/java/ceo/dog/RandomImageTest.java
+++ b/src/test/java/ceo/dog/RandomImageTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.*;
 
 public class RandomImageTest {
 
-    // The Dog API project only accepts jpg files per https://github.com/jigsawpieces/dog-api-images/?tab=readme-ov-file#submission-guide
     @Test(groups ={"smoke", "regression"})
     public void testStatusCodeAndFileType() {
         given()
@@ -18,6 +17,6 @@ public class RandomImageTest {
                 .get(Urls.DOG_API + Endpoints.RANDOM_IMAGE)
                 .then()
                 .statusCode(200)
-                .body("message", endsWith(".jpg"));
+                .body("message", endsWith(".jpg")); /* The Dog API project only accepts jpg files */
     }
 }

--- a/src/test/java/ceo/dog/RandomImageTest.java
+++ b/src/test/java/ceo/dog/RandomImageTest.java
@@ -4,7 +4,6 @@ import ceo.dog.application.Endpoints;
 import ceo.dog.application.Urls;
 import org.testng.annotations.Test;
 
-import static ceo.dog.application.Urls.DOG_API;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 

--- a/src/test/java/ceo/dog/RandomImageTest.java
+++ b/src/test/java/ceo/dog/RandomImageTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.*;
 public class RandomImageTest {
 
     @Test(groups ={"smoke", "regression"})
-    public void testStatusCodeAndFileType() {
+    public void testStatusAndFileType() {
         given()
                 .when()
                 .get(Urls.DOG_API + Endpoints.RANDOM_IMAGE)

--- a/src/test/java/ceo/dog/application/responseParsers/AllBreeds.java
+++ b/src/test/java/ceo/dog/application/responseParsers/AllBreeds.java
@@ -1,0 +1,58 @@
+package ceo.dog.application.responseParsers;
+
+import ceo.dog.application.Endpoints;
+import ceo.dog.application.Urls;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Method;
+import io.restassured.parsing.Parser;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.testng.Assert;
+
+import static io.restassured.RestAssured.given;
+
+import java.lang.reflect.Array;
+import java.util.*;
+
+public class AllBreeds {
+    public static String getRandomBreedName() {
+        Set<String> breedNames = getBreedNames();
+        if (breedNames.isEmpty()) {
+            throw new IllegalArgumentException("The set of breed names is empty.");
+        }
+        int randomIndex = new Random().nextInt(breedNames.size());
+        int i = 0;
+        for (String breedName : breedNames) {
+            if (i == randomIndex) {
+                return breedName;
+            }
+            i++;
+        }
+        throw new IllegalStateException("Something went wrong while picking a random element.");
+    }
+
+    private static Set<String> getBreedNames() {
+        RestAssured.defaultParser = Parser.JSON;
+
+        RequestSpecification httpRequest = given();
+        Response response = httpRequest.request(Method.GET, Urls.DOG_API + Endpoints.ALL_BREEDS);
+
+        Assert.assertEquals(response.getStatusCode(), 200);
+
+        /* The response body message field contains a linked hash map of breeds (key)
+        and their sub-breeds (values). Some api endpoints take a breed value as a param,
+        e.g., list all sub-breeds for a given breed. The set returned here serves as a
+        helper by which a method can obtain a single breed name to pass to an endpoint.*/
+        LinkedHashMap<String, Array> message =
+                given()
+                        .when()
+                        .get(Urls.DOG_API + Endpoints.ALL_BREEDS)
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .path("message");
+
+        return message.keySet();
+    }
+}


### PR DESCRIPTION
# Implementation
- added test to get image by breed
- introduced supporting method to get all breeds and pick random item from array to pass to image-by-breed endpoint
- renamed existing test for consistency

# Testing
```
mvn clean install
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```
