### PR TITLE
add test for sub-breeds list

### DIFF
--- a/src/test/java/ceo/dog/ListSubBreedsTest.java
+++ b/src/test/java/ceo/dog/ListSubBreedsTest.java
@@ -1,0 +1,30 @@
+package ceo.dog;
+
+import ceo.dog.application.Endpoints;
+import ceo.dog.application.Urls;
+import ceo.dog.application.responseParsers.AllBreeds;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ListSubBreedsTest {
+    @Test(groups ={"smoke", "regression"})
+    public void testSubBreedStatusAndContent() {
+        String breedName = AllBreeds.getBreedWithSubBreedsName();
+
+        ArrayList<String> message = given()
+                .when()
+                .get(Urls.DOG_API + Endpoints.subBreedsByBreed(breedName))
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("message");
+
+        assertThat(message, not(is(empty())));
+        assertThat(message.get(0), not(is(emptyString())));
+    }
+}

--- a/src/test/java/ceo/dog/application/responseParsers/AllBreeds.java
+++ b/src/test/java/ceo/dog/application/responseParsers/AllBreeds.java
@@ -3,16 +3,8 @@ package ceo.dog.application.responseParsers;
 import ceo.dog.application.Endpoints;
 import ceo.dog.application.Urls;
 
-import io.restassured.RestAssured;
-import io.restassured.http.Method;
-import io.restassured.parsing.Parser;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
-import org.testng.Assert;
-
 import static io.restassured.RestAssured.given;
 
-import java.lang.reflect.Array;
 import java.util.*;
 
 public class AllBreeds {
@@ -32,27 +24,54 @@ public class AllBreeds {
         throw new IllegalStateException("Something went wrong while picking a random element.");
     }
 
+    public static String getBreedWithSubBreedsName() {
+        LinkedHashMap<String, ArrayList<String>> breeds = getBreedsAndSubBreeds();
+
+        for (Map.Entry<String, ArrayList<String>> breed : breeds.entrySet()) {
+            String key = breed.getKey();
+            ArrayList<String> value = breed.getValue();
+
+            if (!value.isEmpty()) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    public static String getBreedWithoutSubBreedsName() {
+        LinkedHashMap<String, ArrayList<String>> breeds = getBreedsAndSubBreeds();
+
+        for (Map.Entry<String, ArrayList<String>> breed : breeds.entrySet()) {
+            String key = breed.getKey();
+            ArrayList<String> value = breed.getValue();
+
+            if (value.isEmpty()) {
+                return key;
+            }
+        }
+        return null;
+    }
+
     private static Set<String> getBreedNames() {
-        RestAssured.defaultParser = Parser.JSON;
+        LinkedHashMap<String, ArrayList<String>> message = getBreedsAndSubBreeds();
 
-        RequestSpecification httpRequest = given();
-        Response response = httpRequest.request(Method.GET, Urls.DOG_API + Endpoints.ALL_BREEDS);
+        return message.keySet();
+    }
 
-        Assert.assertEquals(response.getStatusCode(), 200);
-
+    private static LinkedHashMap<String, ArrayList<String>> getBreedsAndSubBreeds() {
         /* The response body message field contains a linked hash map of breeds (key)
         and their sub-breeds (values). Some api endpoints take a breed value as a param,
         e.g., list all sub-breeds for a given breed. The set returned here serves as a
         helper by which a method can obtain a single breed name to pass to an endpoint.*/
-        LinkedHashMap<String, Array> message =
-                given()
-                        .when()
-                        .get(Urls.DOG_API + Endpoints.ALL_BREEDS)
-                        .then()
-                        .statusCode(200)
-                        .extract()
-                        .path("message");
+        LinkedHashMap<String, ArrayList<String>> message;
+        message = given()
+                .when()
+                .get(Urls.DOG_API + Endpoints.ALL_BREEDS)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("message");
 
-        return message.keySet();
+        return message;
     }
 }


### PR DESCRIPTION
# Implementation
add test for sub-breeds list endpoint

# Testing
## Negative
verify test failure message when no sub-breeds are found by passing a breed without sub-breeds with the request:
<img width="1184" alt="sub-breeds fail simulation" src="https://github.com/carolmirakove/ApiTestsRestAssured/assets/747777/093249c9-a80b-4af1-9a36-478178a21942">

```
java.lang.AssertionError: 
Expected: not is an empty collection
     but: was <[]>
```

## Positive
```
mvn clean install
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

```
